### PR TITLE
Remove commented-out Docker login from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
         uses: docker/build-push-action@v7
         with:
-          # push: true
           tags: anarkiwi/headlessvice:latest


### PR DESCRIPTION
Dead code cleanup. `docker.yml` already publishes `anarkiwi/headlessvice` on `main` pushes and `v*` tags using `DOCKER_USERNAME` + `DOCKER_TOKEN` — the commented login here would have referenced the old `DOCKERHUB_*` secret names (no longer in use anywhere in the org).

Test workflow stays as a build-only verification — no push from PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)