### PR TITLE
Drop pip ecosystem from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

No `requirements.txt` or `pyproject.toml` lives in this repo, so the pip ecosystem has been failing daily with `dependency_file_not_found: "No files found in /"`. Keep `docker` (Dockerfile exists) and `github-actions`.

## Test plan

- [ ] No new `Dependabot Updates` failures appear after merge.