### PR TITLE
Bound make parallelism to avoid lex/yacc race

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone https://github.com/anarkiwi/asid-vice
 WORKDIR /vice/asid-vice
 RUN aclocal && autoheader && autoconf && automake --force-missing --add-missing && ./autogen.sh && \
     ./configure --enable-headlessui --disable-pdf-docs --without-pulse --without-alsa --without-png --disable-dependency-tracking --disable-realdevice --disable-rs232 --disable-ipv6 --disable-native-gtk3ui --disable-sdlui --disable-sdlui2 --disable-ffmpeg
-RUN make -j all && make install
+RUN make -j"$(nproc)" all && make install
 
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -yq libcurl4 libgomp1 zlib1g python3 python3-pip python3-psutil python3-pandas && apt -y autoremove && apt-get clean && pip install --break-system-packages pyarrow


### PR DESCRIPTION
## Summary

The Dockerfile builds asid-vice with `make -j all` (unlimited parallel jobs). asid-vice's monitor lex/yacc generated files (`mon_lex.c`, `mon_parse.c`) don't have hard dependency edges to the `.o` rules in every code path, so under unlimited concurrency the compile of `mon_lex.o` can race ahead of the lex step and fail with `Error 1`.

Observed on PR #18: same SHA, `push` event built cleanly, `pull_request` event failed at `src/monitor/mon_lex.o`.

Bound the build to `make -j"$(nproc)"` instead of `-j` so concurrency is capped at the runner's core count. Faster than `-j1`, much less prone to the race than `-j` with no bound.

## Test plan

- [ ] `test` workflow builds cleanly on this PR.
- [ ] Re-run a few times if possible to confirm the race is gone (or at least less frequent).

If it still flakes, the next step is to pre-build the lex/yacc files (`make -C src/monitor mon_lex.c mon_parse.c`) before the parallel compile.