### PR TITLE
Pre-generate monitor lex/yacc files before parallel build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN git clone https://github.com/anarkiwi/asid-vice
 WORKDIR /vice/asid-vice
 RUN aclocal && autoheader && autoconf && automake --force-missing --add-missing && ./autogen.sh && \
     ./configure --enable-headlessui --disable-pdf-docs --without-pulse --without-alsa --without-png --disable-dependency-tracking --disable-realdevice --disable-rs232 --disable-ipv6 --disable-native-gtk3ui --disable-sdlui --disable-sdlui2 --disable-ffmpeg
-RUN make -j"$(nproc)" all && make install
+RUN make -C src/monitor mon_parse.h mon_parse.c mon_lex.c && \
+    make -j"$(nproc)" all && make install
 
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -yq libcurl4 libgomp1 zlib1g python3 python3-pip python3-psutil python3-pandas && apt -y autoremove && apt-get clean && pip install --break-system-packages pyarrow


### PR DESCRIPTION
## Summary

Follow-up to #19. Bounding `-j` to `$(nproc)` wasn't enough — the parallel race still fires on the GitHub runner. The actual problem is a missing dependency edge:

- `mon_lex.c` (generated by flex from `mon_lex.l`) references `CMD_KEYMATRIX` and friends declared in `mon_parse.h`.
- `mon_parse.h` is generated by bison from `mon_parse.y`.
- The Makefile only declares those generated files in `BUILT_SOURCES`; the per-object rules don't depend on `mon_parse.h`. Under `-j`, the compile of `mon_lex.o` still races ahead of the bison run.

Failure on PR #19's merge commit confirms this — same symptom on `mon_lex.l:198:32: error: 'CMD_KEYMATRIX' undeclared`.

Fix: pre-build the three BUILT_SOURCES (`mon_parse.h`, `mon_parse.c`, `mon_lex.c`) in `src/monitor` first, then run the parallel build. Adds ~1s to the build; eliminates the race.

## Test plan

- [ ] `test` workflow builds cleanly on this PR (re-run a few times to confirm).