### PR TITLE
fix: clone asid-vice with --recursive for the revice submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y git
 RUN apt-get update && apt-get install -y file make autoconf gcc g++ flex bison dos2unix xa65 libcurl4-openssl-dev pkg-config zlib1g-dev python3-pytest python3-zstandard python3-psutil
 
 WORKDIR /vice
-RUN git clone https://github.com/anarkiwi/asid-vice
+RUN git clone --recursive https://github.com/anarkiwi/asid-vice
 
 # We need asid-vice for multi SID support
 WORKDIR /vice/asid-vice


### PR DESCRIPTION
## Problem

A fresh build fails compiling `src/monitor/mon_parse.c`:

```
mon_parse.y:61:10: fatal error: mon_keymatrix.h: No such file or directory
make[4]: *** [Makefile:606: mon_parse.o] Error 1
```

`asid-vice` vendors `src/revice` (→ `anarkiwi/revice`) as a **git submodule**, which provides `src/revice/libs/keymatrix/vice/mon_keymatrix.{c,h}` (referenced by `src/monitor/Makefile.am`). The Dockerfile does `git clone https://github.com/anarkiwi/asid-vice` **without `--recursive`**, so the submodule is empty and the header is missing. (The published image predates the submodule split, so it isn't affected.)

## Fix

Clone with `--recursive` so the submodule is populated and the build finds `mon_keymatrix.h`.

```diff
-RUN git clone https://github.com/anarkiwi/asid-vice
+RUN git clone --recursive https://github.com/anarkiwi/asid-vice
```

## Verified

With this change the image **builds cleanly from scratch on linux/arm64** (native, Apple Silicon). Note: this fixes the *compile*; on arm64 the resulting `vsid` still segfaults at runtime when rendering a SID, which looks like a separate emulator-core issue (out of scope here) — amd64 builds and runs fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)