### PR TITLE
fix: make run_processor picklable for multiprocessing forkserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ RUN make -C src/monitor mon_parse.h mon_parse.c mon_lex.c && \
     make -j"$(nproc)" all && make install
 
 FROM ubuntu:latest
-RUN apt-get update && apt-get install -yq libcurl4 libgomp1 zlib1g python3 python3-pip python3-psutil python3-pandas && apt -y autoremove && apt-get clean && pip install --break-system-packages pyarrow
+RUN apt-get update && apt-get install -yq libcurl4 libgomp1 zlib1g python3 python3-pip python3-psutil python3-pandas python3-pytest && apt -y autoremove && apt-get clean && pip install --break-system-packages pyarrow
 COPY --from=builder /usr/local /usr/local
 COPY vsiddump.py /usr/local/bin/vsiddump.py
+COPY test_vsiddump.py /usr/local/bin/test_vsiddump.py
 
+RUN cd /usr/local/bin && python3 -m pytest test_vsiddump.py -v && rm test_vsiddump.py
 RUN /usr/local/bin/vsid -h -console -silent
 RUN /usr/local/bin/vsiddump.py --dump /tmp/test.zst --help

--- a/test_vsiddump.py
+++ b/test_vsiddump.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import multiprocessing
+import os
+import pickle
+import tempfile
+
+import pandas as pd
+import pytest
+
+import vsiddump
+
+
+# Columns vsid emits to the fifo, space separated, no header:
+# clock_diff irq_diff nmi_diff chipno reg val
+SAMPLE_DUMP = """\
+0 0 0 0 0 16
+10 0 0 0 1 32
+10 0 0 0 1 32
+10 0 0 0 4 17
+10 0 0 0 25 255
+10 0 0 0 1 48
+"""
+
+
+def write_dump(tmpdir, contents=SAMPLE_DUMP):
+    path = os.path.join(tmpdir, "dump")
+    with open(path, "w", encoding="utf8") as f:
+        f.write(contents)
+    return path
+
+
+def test_run_processor_is_picklable():
+    # On Python 3.14 the default multiprocessing start method on Linux is
+    # forkserver, which pickles the target. A local closure would fail here.
+    pickle.loads(pickle.dumps(vsiddump.run_processor))
+
+
+def test_process_dump_basic():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = vsiddump.process_dump(write_dump(tmpdir))
+    assert list(df.columns) == ["clock", "irq", "chipno", "reg", "val"]
+    # reg 25 is > MAX_REG (24) and must be dropped.
+    assert df["reg"].max() <= vsiddump.MAX_REG
+    # clock is the cumulative sum of clock_diff.
+    assert df["clock"].is_monotonic_increasing
+    # Duplicate reg=1 val=32 write is squeezed out (no change).
+    reg1 = df[df["reg"] == 1]["val"].tolist()
+    assert reg1 == [32, 48]
+
+
+def test_process_dump_dtypes():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        df = vsiddump.process_dump(write_dump(tmpdir))
+    assert df["clock"].dtype == vsiddump.PDTYPE
+    assert df["irq"].dtype == vsiddump.PDTYPE
+    assert df["chipno"].dtype == pd.UInt8Dtype()
+    assert df["reg"].dtype == pd.UInt8Dtype()
+    assert df["val"].dtype == pd.UInt8Dtype()
+
+
+def test_run_processor_writes_parquet():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fifoname = write_dump(tmpdir)
+        dumpname = os.path.join(tmpdir, "out.dump.parquet")
+        vsiddump.run_processor(fifoname, dumpname)
+        assert os.path.exists(dumpname)
+        df = pd.read_parquet(dumpname)
+    assert list(df.columns) == ["clock", "irq", "chipno", "reg", "val"]
+
+
+def test_run_processor_in_subprocess():
+    # Exercises the same path that failed in the bug report: launching a
+    # multiprocessing.Process with run_processor as the target.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fifoname = write_dump(tmpdir)
+        dumpname = os.path.join(tmpdir, "out.dump.parquet")
+        ctx = multiprocessing.get_context("forkserver")
+        proc = ctx.Process(target=vsiddump.run_processor, args=(fifoname, dumpname))
+        proc.start()
+        proc.join()
+        assert proc.exitcode == 0
+        assert os.path.exists(dumpname)
+
+
+def test_reduce_res_masks_registers():
+    df = pd.DataFrame(
+        {
+            "clock": [0, 1, 2],
+            "irq": [0, 0, 0],
+            "chipno": [0, 0, 0],
+            "reg": [3, 21, 23],
+            "val": [0xFF, 0xFF, 0xFF],
+        }
+    )
+    out = vsiddump.reduce_res(df)
+    assert out[out["reg"] == 3]["val"].iloc[0] == 0x0F  # PWM high nibble
+    assert out[out["reg"] == 21]["val"].iloc[0] == 0x07  # filter cutoff low 3 bits
+    assert out[out["reg"] == 23]["val"].iloc[0] == 0xF7  # filter external cleared
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/vsiddump.py
+++ b/vsiddump.py
@@ -8,7 +8,6 @@ import subprocess
 import tempfile
 import pandas as pd
 
-
 MAX_REG = 24
 PDTYPE = pd.UInt32Dtype()
 
@@ -77,7 +76,11 @@ def process_dump(fifoname):
 def run_processor(fifoname, dumpname):
     try:
         df = process_dump(fifoname)
-        df.to_parquet(dumpname, compression="zstd")
+        tmp_name = os.path.join(
+            os.path.dirname(dumpname), "." + os.path.basname(dumpname)
+        )
+        df.to_parquet(tmp_name, compression="zstd")
+        os.rename(tmp_name, dumpname)
     except Exception as err:
         print("run_processor() failed:", err)
 

--- a/vsiddump.py
+++ b/vsiddump.py
@@ -41,6 +41,47 @@ def reduce_res(orig_df):
     return df
 
 
+def process_dump(fifoname):
+    with open(fifoname, "r", encoding="utf8") as f:
+        df = pd.read_csv(
+            f,
+            header=None,
+            sep=r"\s+",
+            names=[
+                "clock_diff",
+                "irq_diff",
+                "nmi_diff",
+                "chipno",
+                "reg",
+                "val",
+            ],
+        )
+    df["clock"] = df["clock_diff"].cumsum()
+    df["irq"] = (df["clock"] - df["irq_diff"]).clip(lower=0)
+    df = df[df["reg"] <= MAX_REG]
+    df = df[["clock", "irq", "chipno", "reg", "val"]]
+    df = reduce_res(df)
+    df = squeeze_changes(df)
+    df = df.astype(
+        {
+            "clock": PDTYPE,
+            "irq": PDTYPE,
+            "chipno": pd.UInt8Dtype(),
+            "reg": pd.UInt8Dtype(),
+            "val": pd.UInt8Dtype(),
+        }
+    )
+    return df
+
+
+def run_processor(fifoname, dumpname):
+    try:
+        df = process_dump(fifoname)
+        df.to_parquet(dumpname, compression="zstd")
+    except Exception as err:
+        print("run_processor() failed:", err)
+
+
 def dumptune(dumpdir, args, vsidargs, tune=None):
     with tempfile.TemporaryDirectory() as tmpdir:
         fifoname = os.path.join(tmpdir, "fifo")
@@ -73,42 +114,9 @@ def dumptune(dumpdir, args, vsidargs, tune=None):
         base = ".".join((base, "dump.parquet"))
         dumpname = os.path.join(dumpdir, base)
 
-        def run_processor():
-            try:
-                with open(fifoname, "r", encoding="utf8") as f:
-                    df = pd.read_csv(
-                        f,
-                        header=None,
-                        delim_whitespace=True,
-                        names=[
-                            "clock_diff",
-                            "irq_diff",
-                            "nmi_diff",
-                            "chipno",
-                            "reg",
-                            "val",
-                        ],
-                    )
-                df["clock"] = df["clock_diff"].cumsum()
-                df["irq"] = (df["clock"] - df["irq_diff"]).clip(lower=0)
-                df = df[df["reg"] <= MAX_REG]
-                df = df[["clock", "irq", "chipno", "reg", "val"]]
-                df = reduce_res(df)
-                df = squeeze_changes(df)
-                df = df.astype(
-                    {
-                        "clock": PDTYPE,
-                        "irq": PDTYPE,
-                        "chipno": pd.UInt8Dtype(),
-                        "reg": pd.UInt8Dtype(),
-                        "val": pd.UInt8Dtype(),
-                    }
-                )
-                df.to_parquet(dumpname, compression="zstd")
-            except Exception as err:
-                print("run_processor() failed:", err)
-
-        processor = multiprocessing.Process(target=run_processor)
+        processor = multiprocessing.Process(
+            target=run_processor, args=(fifoname, dumpname)
+        )
         with subprocess.Popen(
             cli, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ) as vice:


### PR DESCRIPTION
Python 3.14 changed the default multiprocessing start method on Linux from fork to forkserver, which pickles the target function. The worker was a local closure inside dumptune and could not be pickled, raising PicklingError when running a full HVSC dump.

Move the worker to module-level process_dump()/run_processor() and pass the fifo and dump paths as picklable args. Also replace the deprecated delim_whitespace with sep, and add tests (run during the Docker build).